### PR TITLE
Fix two hiccups in local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.4.0",
+    "foreman": "^3.0.1",
     "patch-package": "^5.1.1"
   },
   "homepage": "./",

--- a/src/preload.js
+++ b/src/preload.js
@@ -53,8 +53,8 @@ window.request = async function (uri, cookie, cookieurl, qs) {
 
 
 if (isDev) {
-    window.configPath = path.resolve(window.dirname + "/../config.json");
-    window.sqlitePath = path.resolve(window.dirname + "/../rsdb.sqlite");
+    window.configPath = path.resolve(window.dirname + "/../config.dev.json");
+    window.sqlitePath = path.resolve(window.dirname + "/../rsdb.dev.sqlite");
 }
 else {
     window.configPath = path.resolve(window.remote.app.getPath("userData") + "/config.json");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,6 +1825,10 @@ commander@2.15.x, commander@^2.11.0, commander@^2.9.0, commander@~2.15.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
+commander@^2.15.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -3402,6 +3406,15 @@ foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
+foreman@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/foreman/-/foreman-3.0.1.tgz#805f28afc5a4bbaf08dbb1f5018c557dcbb8a410"
+  dependencies:
+    commander "^2.15.1"
+    http-proxy "^1.17.0"
+    mustache "^2.2.1"
+    shell-quote "^1.6.1"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -3965,7 +3978,7 @@ http-proxy-middleware@~0.17.4:
     lodash "^4.17.2"
     micromatch "^2.3.11"
 
-http-proxy@^1.16.2:
+http-proxy@^1.16.2, http-proxy@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
   dependencies:
@@ -5394,6 +5407,10 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+mustache@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -7336,7 +7353,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@1.6.1:
+shell-quote@1.6.1, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   dependencies:


### PR DESCRIPTION
### Add foreman package

**Without:**

```bash
$ yarn start
yarn run v1.6.0
nf start -p 3000
/bin/sh: nf: command not found
error Command failed with exit code 127.
```

**With**: `yarn start` works as expected

### Use `.dev` config/db

- gitignore ignores 'config.dev.json' and 'rsdb.dev.sqlite'
- So use those when isDev, to avoid writing changes to tracked files
  config.json and rsdb.sqlite
70e458e

### Notes

The two commits are separate, so if you want just one, can drop the other... IE, if you don't want foreman as a dependency, I can drop that commit, and maybe commit a note saying to npm that package globally if you see the `nf` error