### PR TITLE
Count songs RIGHT at the mastery threshold..

### DIFF
--- a/src/sqliteService.js
+++ b/src/sqliteService.js
@@ -450,7 +450,7 @@ export async function getArrangmentsMastered(useCDLC = false) {
     db = await window.sqlite.open(dbfilename);
   }
   const masteryT = await getMasteryThresholdConfig();
-  const sql = `select count(mastery) as count from songs_owned where mastery > '${masteryT}' ${cdlcSql};`;
+  const sql = `select count(mastery) as count from songs_owned where mastery >= '${masteryT}' ${cdlcSql};`;
   const output = await db.get(sql);
   return output;
 }


### PR DESCRIPTION
If you set the mastery threshold at 100, you want to get all the songs you've
achieved exactly 100% on, to match how RS shows "songs mastered" on it's
stats screen.

Since I don't use master mode much, adding that = in there takes me from
6 songs mastered to over 1000 :p

Thanks for the new updates, this tool is getting more and more fantastic! 