### PR TITLE
Remember window size/location

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dotenv-expand": "4.2.0",
     "electron-is-dev": "^0.3.0",
     "electron-prompt": "^1.0.0",
+    "electron-window-state": "^5.0.1",
     "express": "^4.16.3",
     "find-process": "^1.1.1",
     "fs-extra": "3.0.1",

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -4,18 +4,32 @@ const path = require("path");
 const url = require("url");
 const d = require('debug')('index');
 const isDev = require('electron-is-dev');
+const windowStateKeeper = require('electron-window-state');
 let mainWindow;
 
 function createWindow() {
+    // Load the previous state with fallback to defaults
+    let mainWindowState = windowStateKeeper({
+      defaultWidth: 1750,
+      defaultHeight: 1036
+    });
+
+    // Create the window using the state information
     mainWindow = new BrowserWindow({
-        width: 1750,
-        height: 1036,
+        x: mainWindowState.x,
+        y: mainWindowState.y,
+        width: mainWindowState.width,
+        height: mainWindowState.height,
         icon: path.join(__dirname, "./icons/png/icon-1024x1024.png"),
         webPreferences: {
             preload: path.join(__dirname, "./preload.js"),
             webSecurity: false,
         },
     });
+    // Let us register listeners on the window, so we can update the state
+    // automatically (the listeners will be removed when the window is closed)
+    // and restore the maximized or full screen state
+    mainWindowState.manage(mainWindow);
     mainWindow.setAutoHideMenuBar(true)
     //mainWindow.maximize();
     if (isDev) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2665,6 +2665,14 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.49"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.49.tgz#651384b0d81f078a96639b2b36975141b7915004"
 
+electron-window-state@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/electron-window-state/-/electron-window-state-5.0.1.tgz#ebda7b789e4bd2ab5c439c22090b159effe6a12d"
+  dependencies:
+    deep-equal "^1.0.1"
+    jsonfile "^4.0.0"
+    mkdirp "^0.5.1"
+
 electron@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.3.tgz#8e591e820cae2ccdb0c3fd74c6d07834913fc133"


### PR DESCRIPTION
Remember window size/location so you don't have to manually drag the window over each time you start it.

- [ x Tested it on Mac, works well
  - First time, it opens same place it always has
  - Move it somewhere else, resize to taste, close it
  - When you reopen, it's back where you wanted 
- [ ] Test on windows
  - No windows here..