### PR TITLE
Add ()'s to setlist filters

### DIFF
--- a/src/Components/setlistOptions.js
+++ b/src/Components/setlistOptions.js
@@ -248,7 +248,7 @@ export default class SetlistOptions extends React.Component {
       sortoptions: defaultSortOption,
     }
     //tuning
-    this.gates = ["and", "or"]
+    this.gates = ["and", "or", "and (", "or (", ")", ") and", ") or"]
     this.fields = [
       {
         type: "artist",


### PR DESCRIPTION
Adds various parentheses/and/or combination to the logic gates, so you can do things like:
- Find lead songs by this artist or that artist
- Find bass songs you've not both 100%'d and FC'd

### For example

![screen shot 2019-02-13 at 1 28 01 pm](https://user-images.githubusercontent.com/1568662/52741948-d9a9e980-2f93-11e9-9041-0b0151403c9f.png)

generates:

```sql
select * from songs_owned 
where is_cdlc is 'false' 
and path_bass = 1 
and ( 
  coalesce(mastery,0) < 1 
  or 
  sa_fc_hard IS NULL 
) 
and song not like '%nonsensebecauseclosing%20%29%20needed%'
```

And spits out what's needed

## Just the options:

![screen shot 2019-02-13 at 1 39 30 pm](https://user-images.githubusercontent.com/1568662/52742403-e4b14980-2f94-11e9-9afc-77f1b54a461e.png)


## Would be even better if...

It would add the logic chain option on the last entry if an opening `(` is there but no `)` - but I'm not sure how to add that. 