### PR TITLE
Show cents offset as tooltip..

### DIFF
--- a/src/Components/songlistView.js
+++ b/src/Components/songlistView.js
@@ -478,7 +478,7 @@ export function tuningFormatter(cell, row) {
       let offset = ""
       const freq = (concertpitch * (2.0 ** (row.centoffset / 1200.0)))
       if (freq !== (concertpitch)) {
-        offset = `(${Math.floor(freq)} Hz)`
+        offset = ` (${Math.floor(freq)} Hz)`
       }
       let suffix = "";
       if (row.capofret !== 0 && row.capofret !== "" && row.capofret !== "0") {
@@ -497,7 +497,29 @@ export function tuningFormatter(cell, row) {
             break;
         }
       }
-      return <span title={cell}>{tuningkeys[i]}<span className={suffix === "" ? "hidden" : ""}>(Capo: {row.capofret}<sup>{suffix})</sup></span> {offset}</span>
+      return (
+        <Fragment>
+          <ReactTooltip
+            id={row.id + "_tuning"}
+            aria-haspopup="true"
+            place="right"
+            type="dark"
+            effect="solid"
+            className="tooltipClass">
+            Cent Offset: {row.centoffset}
+          </ReactTooltip>
+
+          <div data-tip data-for={row.id + "_tuning"} data-class="tooltip-offset tooltipClass">
+            <span title={cell}>
+              {tuningkeys[i]}
+              <span className={suffix === "" ? "hidden" : ""}>
+                (Capo: {row.capofret}<sup>{suffix})</sup>
+              </span>
+              {offset}
+            </span>
+          </div>
+        </Fragment>
+      )
     }
   }
   return <span>Custom {JSON.stringify(combinedt)}</span>


### PR DESCRIPTION
Makes it so hovering over the tuning info, shows the offset in cents (as opposed to concert tuning in the list): 

![screen shot 2019-02-13 at 2 01 59 pm](https://user-images.githubusercontent.com/1568662/52743882-47f0ab00-2f98-11e9-8c30-ec52d01f0223.png)

That way you can see what to set your pitch shifter to if you're using [something](https://www.fractalaudio.com/iii/) to detune your guitar 