### PR TITLE
Add DADGAD tuning

### DIFF
--- a/src/Components/setlistOptions.js
+++ b/src/Components/setlistOptions.js
@@ -40,7 +40,7 @@ function generateAnyTuningSql(filter) {
   const allNonStandardJSON = allNonStandardTunings.map(e => tunings[e])
 
   const allOpenTunings = [
-    "Open A", "Open D", "Open G", "Open E",
+    "Open A", "Open D", "Open G", "Open E", "DADGAD",
   ]
   const allOpenJSON = allOpenTunings.map(e => tunings[e]);
 

--- a/src/Components/songlistView.js
+++ b/src/Components/songlistView.js
@@ -43,6 +43,7 @@ export const allTunings = {
   "Open D": [-2, 0, 0, -1, -2, -2],
   "Open G": [-2, -2, 0, 0, 0, -2],
   "Open E": [0, 2, 2, 1, 0, 0],
+  DADGAD: [-2, 0, 0, 0, -2, -2],
 }
 export const techniqueNames = {
   barreChords: "Barre Chords",


### PR DESCRIPTION
# Before;

The new 5SoS song shows up as a cryptic -2,0,0,0,-2,2:

![Screen Shot 2019-05-31 at 11 45 14 AM](https://user-images.githubusercontent.com/1568662/58724536-1f02f300-839a-11e9-9317-23875f8e422f.png)

# After:

Hooray for alt tunings!

![Screen Shot 2019-05-31 at 11 46 29 AM](https://user-images.githubusercontent.com/1568662/58724566-34781d00-839a-11e9-8f77-8f61f3cd8202.png)

# Setlist Search

![Screen Shot 2019-05-31 at 11 46 54 AM](https://user-images.githubusercontent.com/1568662/58724587-43f76600-839a-11e9-91ad-430dfb97ae1c.png)

![Screen Shot 2019-05-31 at 11 47 33 AM](https://user-images.githubusercontent.com/1568662/58724589-4659c000-839a-11e9-9a8a-6423c245ca0b.png)

![Screen Shot 2019-05-31 at 11 47 47 AM](https://user-images.githubusercontent.com/1568662/58724753-a8b2c080-839a-11e9-9d2a-4648bacc5ce3.png)

# Open Tunings?

Added it in with Open A/D/G/E, since its technically an open chord (Dsus4) - but if you think that the "Any Open Tuning" filter shouldn't return the DADGADs, can be removed from that list

