### PR TITLE
Insert scanned .psarc's with upsert..

### DIFF
--- a/src/sqliteService.js
+++ b/src/sqliteService.js
@@ -672,7 +672,42 @@ export async function updateSongsOwnedV2(songs, isCDLC = false) {
         items += ',';
       }
     }
-    sql = `INSERT OR IGNORE INTO songs_owned (album, artist, song, arrangement, json, psarc, dlc, sku, difficulty, dlckey, songkey, id,uniqkey, lastConversionTime, mastery, count, arrangementProperties, capofret, centoffset, tuning, songLength, maxNotes, tempo, is_cdlc, tuning_weight, path_lead, path_rhythm, path_bass, bonus_arr, represent) VALUES ${items}`;
+    sql = `
+      INSERT OR IGNORE INTO songs_owned (
+        album, artist, song, arrangement, json, psarc, dlc, sku, difficulty, dlckey, songkey, id, uniqkey, lastConversionTime, mastery, count, arrangementProperties, capofret, centoffset, tuning, songLength, maxNotes, tempo, is_cdlc, tuning_weight, path_lead, path_rhythm, path_bass, bonus_arr, represent
+      ) VALUES ${items}
+      ON CONFLICT(id) DO UPDATE SET
+        album=excluded.album,
+        artist=excluded.artist,
+        song=excluded.song,
+        arrangement=excluded.arrangement,
+        json=excluded.json,
+        psarc=excluded.psarc,
+        dlc=excluded.dlc,
+        sku=excluded.sku,
+        difficulty=excluded.difficulty,
+        dlckey=excluded.dlckey,
+        songkey=excluded.songkey,
+        uniqkey=excluded.uniqkey,
+        lastConversionTime=excluded.lastConversionTime,
+        mastery=mastery,
+        count=count,
+        arrangementProperties=excluded.arrangementProperties,
+        capofret=excluded.capofret,
+        centoffset=excluded.centoffset,
+        tuning=excluded.tuning,
+        songLength=excluded.songLength,
+        maxNotes=excluded.maxNotes,
+        tempo=excluded.tempo,
+        is_cdlc=excluded.is_cdlc,
+        tuning_weight=excluded.tuning_weight,
+        path_lead=excluded.path_lead,
+        path_rhythm=excluded.path_rhythm,
+        path_bass=excluded.path_bass,
+        bonus_arr=excluded.bonus_arr,
+        represent=excluded.represent;
+      `;
+    // console.log(sql);
     try {
       //eslint-disable-next-line
       const op = await db.run(sql);


### PR DESCRIPTION
# Problem

- There's reasons you'd want to update your already scanned songs:
  - Missing Data
    - Once custom columns were added, it jumped that most of my `songs_owned` were missing `maxNotes` and `duration` - they'd been scanned before those were added
  - Changed Data
    - Ubi sometimes updates songs.. for example, in the recent 64bit catalina update:
       - Trex - 20th Century Boy changed to true E Standard instead of a cent offset tuning
       - Oasis - Don't Look Back in Anger (Lead) lost a note 
       - Boston - Peace of Mind (Bass) changed some notes around
  - But if you go to the PSARC explorer and rescan now, it'll just skip over them.  
  - Deleting and rescanning would be pain, because you'd lose them from setlists

# Fix 

Hooray, sqlite has [upsert](https://www.sqlite.org/lang_UPSERT.html) now!  

# Example:

### Before:
![Screen Shot 2019-10-14 at 11 45 11 AM](https://user-images.githubusercontent.com/1568662/66772445-fd526600-ee79-11e9-8140-303b9d03425f.png)

### After:

![Screen Shot 2019-10-14 at 11 45 32 AM](https://user-images.githubusercontent.com/1568662/66772518-23780600-ee7a-11e9-9d29-8ca0bde54cbd.png)


### Upsert SQL

 (just hitting Choose psarc file in the psarc Explorer and Update Songs Owned)

```sql
 INSERT OR IGNORE INTO songs_owned (
  album, artist, song, arrangement, json, psarc, dlc, sku, difficulty, dlckey, songkey, id, uniqkey, lastConversionTime, mastery, count, arrangementProperties, capofret, centoffset, tuning, songLength, maxNotes, tempo, is_cdlc, tuning_weight, path_lead, path_rhythm, path_bass, bonus_arr, represent
) VALUES (
    'Suspicious%20Minds', 'Elvis%20Presley', 'Suspicious%20Minds', 'Rhythm', 'manifests/songs_dlc_elvisusp/elvisusp_rhythm.json', 'Elvis%20Presley%20-%20Suspicious%20Minds%20_m.psarc', 'true', 'RS2',
    '2.1999999999999997','ElviSusp', 'ElviSusp', '405B31507469715F1D9314B8896729B2', '/path/to/file_m.psarc_ElviSusp_Rhythm_405B31507469715F1D9314B8896729B2', '08-4-16%2011%3A25', '0', '0',
    '<big ol json blob>', '0', '0', '<big ol tuning blob>', '278', '1102', '120', 'false',
    '0', '0', '1', '0', '0', '1'
  ),(
    'Suspicious%20Minds', 'Elvis%20Presley', 'Suspicious%20Minds', 'Lead', 'manifests/songs_dlc_elvisusp/elvisusp_lead3.json', 'Elvis%20Presley%20-%20Suspicious%20Minds%20_m.psarc', 'true', 'RS2',
    '3','ElviSusp', 'ElviSusp', 'AE73EBDC4A3C8EF01478F00018DD486C', '/path/to/file_m.psarc_ElviSusp_Lead3_AE73EBDC4A3C8EF01478F00018DD486C', '08-4-16%2011%3A21', '0', '0',
    '<big ol json blob>', '0', '0', '<big ol tuning blob>', '278', '419', '120', 'false',
    '0', '1', '0', '0', '0', '1'
  ),(
    'Suspicious%20Minds', 'Elvis%20Presley', 'Suspicious%20Minds', 'Lead', 'manifests/songs_dlc_elvisusp/elvisusp_lead.json', 'Elvis%20Presley%20-%20Suspicious%20Minds%20_m.psarc', 'true', 'RS2',
    '3','ElviSusp', 'ElviSusp', '87356802D512F0A02557A70C6CAAC558', '/path/to/file_m.psarc_ElviSusp_Lead_87356802D512F0A02557A70C6CAAC558', '08-4-16%2011%3A25', '0', '0',
    '<big ol json blob>', '0', '0', '<big ol tuning blob>', '278', '1182', '120', 'false',
    '0', '1', '0', '0', '0', '0'
  ),(
    'Suspicious%20Minds', 'Elvis%20Presley', 'Suspicious%20Minds', 'Bass', 'manifests/songs_dlc_elvisusp/elvisusp_bass.json', 'Elvis%20Presley%20-%20Suspicious%20Minds%20_m.psarc', 'true', 'RS2',
    '2.9000000000000004','ElviSusp', 'ElviSusp', 'FD861506CD0FFCB658F238ED52481691', '/path/to/file_m.psarc_ElviSusp_Bass_FD861506CD0FFCB658F238ED52481691', '08-4-16%2011%3A25', '0', '0',
    '<big ol json blob>', '0', '0', '<big ol tuning blob>', '278', '906', '120', 'false',
    '0', '0', '0', '1', '0', '1'
  )
  ON CONFLICT(id) DO UPDATE SET
    album=excluded.album,
    artist=excluded.artist,
    song=excluded.song,
    arrangement=excluded.arrangement,
    json=excluded.json,
    psarc=excluded.psarc,
    dlc=excluded.dlc,
    sku=excluded.sku,
    difficulty=excluded.difficulty,
    dlckey=excluded.dlckey,
    songkey=excluded.songkey,
    uniqkey=excluded.uniqkey,
    lastConversionTime=excluded.lastConversionTime,
    mastery=mastery,
    count=count,
    arrangementProperties=excluded.arrangementProperties,
    capofret=excluded.capofret,
    centoffset=excluded.centoffset,
    tuning=excluded.tuning,
    songLength=excluded.songLength,
    maxNotes=excluded.maxNotes,
    tempo=excluded.tempo,
    is_cdlc=excluded.is_cdlc,
    tuning_weight=excluded.tuning_weight,
    path_lead=excluded.path_lead,
    path_rhythm=excluded.path_rhythm,
    path_bass=excluded.path_bass,
    bonus_arr=excluded.bonus_arr,
    represent=excluded.represent;
```


### Is it safe?

Could probably use more testing... any idea on ways to poke it? 