### PR TITLE
[FIX] Make steam playtime populate correctly

### DIFF
--- a/src/Components/dashboardView.js
+++ b/src/Components/dashboardView.js
@@ -117,6 +117,7 @@ class DashboardView extends React.Component {
         steam.getOwnedGames({
           appids_filter: [221680],
           steamid: steamID,
+          include_free_sub: false,
           include_played_free_games: false,
           include_appinfo: 1,
         }, (err, data) => {


### PR DESCRIPTION
Steam added a required `include_free_sub` param to this API call

![Screen Shot 2020-05-04 at 12 03 45 PM](https://user-images.githubusercontent.com/1568662/80997982-6c37e200-8dff-11ea-83b3-b691f0d65e92.png)

By adding this line, it successfully fetches my hours again